### PR TITLE
Make start button show immediately

### DIFF
--- a/hud.gd
+++ b/hud.gd
@@ -16,14 +16,17 @@ func show_timed_message(text, time):
 func show_game_over(time):
 	show_timed_message("Game Over", time)
 	
+	$StartButton.show()
+	
 	# Wait until the MessageTimer has counted down.
 	await $MessageTimer.timeout
 
-	show_message("Survive!")
+	if $StartButton.visible:
+		show_message("Survive!")
 
-	await get_tree().create_timer(1.0).timeout
+		await get_tree().create_timer(1.0).timeout
 	
-	$StartButton.show()
+	
 
 func update_score(score):
 	$ScoreLabel.text = str(score)
@@ -33,6 +36,8 @@ func _on_message_timer_timeout():
 
 func _on_start_button_pressed():
 	$StartButton.hide()
+	$Message.hide()
+	$MessageTimer.stop()
 	start_game.emit()
 
 # Called when the node enters the scene tree for the first time.

--- a/main.gd
+++ b/main.gd
@@ -23,8 +23,6 @@ func game_over():
 func new_game():
 	score = 0
 	obstacle_gap_size = 300
-	if not $Player.visible:
-		$Player.start($StartPosition.position)
 	$HUD.update_score("Score: %s" % score)
 	$HUD.show_timed_message("Get Ready", $StartTimer.wait_time)
 	$StartTimer.start()
@@ -53,6 +51,8 @@ func _on_obstacle_timer_timeout():
 	add_child(obstacle)
 
 func _on_start_timer_timeout():
+	if not $Player.visible:
+		$Player.start($StartPosition.position)
 	$ObstacleTimer.start()
 	$ScoreTimer.start()
 

--- a/main.gd
+++ b/main.gd
@@ -23,10 +23,12 @@ func game_over():
 func new_game():
 	score = 0
 	obstacle_gap_size = 300
-	$Player.start($StartPosition.position)
+	if not $Player.visible:
+		$Player.start($StartPosition.position)
 	$HUD.update_score("Score: %s" % score)
 	$HUD.show_timed_message("Get Ready", $StartTimer.wait_time)
 	$StartTimer.start()
+	$GameOverSound.stop()
 	$Music.play()
 
 func _on_obstacle_timer_timeout():

--- a/player.gd
+++ b/player.gd
@@ -70,6 +70,7 @@ func _on_body_entered(body):
 
 func start(pos):
 	position = pos
+	speed = 0
 	show()
 	$CollisionShape2D.disabled = false
 


### PR DESCRIPTION
Clicking start switches to game music and initiates round as usual

Also fixed the player being reset on first playthrough which was jarring


https://github.com/Aveli-games/flappy-fish/assets/118833456/3899ae1b-e618-43ca-88fb-f472ba30845f

