### PR TITLE
Local leaderboard fix

### DIFF
--- a/air.gd
+++ b/air.gd
@@ -1,16 +1,6 @@
 extends Area2D
 
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	pass # Replace with function body.
-
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
-	pass
-
-
 func _on_area_entered(area):
 	if area.name == "Player":
 		$ExitWater.play()

--- a/autoloads/local_high_scores.gd
+++ b/autoloads/local_high_scores.gd
@@ -44,7 +44,7 @@ func get_score_rank(score):
 		for entry in scores:
 			var entry_score = int(entry["score"])
 			if int(score) > entry_score:
-				rank = scores.rfind(entry)
+				rank = scores.find(entry)
 				break
 			if int(score) == entry_score:
 				rank = scores.rfind(entry) + 1

--- a/game_score.gd
+++ b/game_score.gd
@@ -1,14 +1,6 @@
 extends HBoxContainer
 
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	pass # Replace with function body.
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
-	pass
-	
 func set_color(color):
 	get_node("Rank").add_theme_color_override("font_color", color)
 	get_node("Name").add_theme_color_override("font_color", color)

--- a/main.gd
+++ b/main.gd
@@ -97,7 +97,7 @@ func _on_score_timer_timeout():
 	score += 1
 	$HUD.update_score("Score: %s" % score)
 	
-func _on_local_high_score(rank):
+func _on_local_high_score(_rank):
 	if $HighScoreSound.get_playback_position() == 0:
 		change_music($HighScoreSound)
 


### PR DESCRIPTION
fixes higher scores getting slotted in the wrong spot, like so:
![Screenshot 2024-01-10 at 9 20 35 AM](https://github.com/Aveli-games/splashy-fish/assets/16199008/7d47e874-5cf8-4e8a-ae26-8029b40f1e64)
